### PR TITLE
Fix entry point for CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,4 +12,7 @@ dependencies = [
 ]
 
 [project.scripts]
-strands-agent = "my_agent.agent_cli:cli"
+strands-agent = "agent_cli:cli"
+
+[tool.setuptools]
+py-modules = ["agent_cli"]


### PR DESCRIPTION
## Summary
- correct console script path
- expose the agent_cli module via setuptools

## Testing
- `pip install -e .`
- `strands-agent --help`

------
https://chatgpt.com/codex/tasks/task_e_6846a295dd5c832485a0ad1058d0c534